### PR TITLE
Fix Vercel API routing: exclude /api from SPA catch-all

### DIFF
--- a/unicorn-vite/vercel.json
+++ b/unicorn-vite/vercel.json
@@ -6,11 +6,7 @@
   "framework": "vite",
   "rewrites": [
     {
-      "source": "/api/(.*)",
-      "destination": "/api/$1"
-    },
-    {
-      "source": "/(.*)",
+      "source": "/(?!api/)(.*)",
       "destination": "/index.html"
     }
   ],


### PR DESCRIPTION
The SPA rewrite was intercepting /api/wallet-activity requests and serving index.html instead of the serverless function.